### PR TITLE
Return a default empty body value when request method is GET

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    action_handler (0.2.1)
+    action_handler (0.2.2)
       activesupport (~> 5.2)
       rack (~> 2.0)
 

--- a/lib/action_handler/sources/http.rb
+++ b/lib/action_handler/sources/http.rb
@@ -98,7 +98,7 @@ module ActionHandler
           {
             'rack.request.form_hash' => JSON.parse(body),
             'rack.request.form_input' => input
-          } if headers['Content-Type'] == 'application/json'
+          } if headers['Content-Type'] == 'application/json' && body.to_s.length.positive?
         end
       end
     end

--- a/lib/action_handler/version.rb
+++ b/lib/action_handler/version.rb
@@ -1,3 +1,3 @@
 module ActionHandler
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/action_handler/sources/http_spec.rb
+++ b/spec/action_handler/sources/http_spec.rb
@@ -69,6 +69,32 @@ RSpec.describe ActionHandler::Sources::HTTP do
           expect(params[:level]).to eq(32)
         end
       end
+
+      context 'nil body' do
+        let(:body)  { nil }
+        let(:event) { { 'headers' => headers, 'body' => body } }
+
+        it 'should return an ActionHandler::Params object' do
+          expect(params.class).to eq(ActionHandler::Params)
+        end
+
+        it 'should have empty params' do
+          expect(params.to_h).to be_empty
+        end
+      end
+
+      context 'empty body' do
+        let(:body)  { '' }
+        let(:event) { { 'headers' => headers, 'body' => body } }
+
+        it 'should return an ActionHandler::Params object' do
+          expect(params.class).to eq(ActionHandler::Params)
+        end
+
+        it 'should have empty params' do
+          expect(params.to_h).to be_empty
+        end
+      end
     end
 
     context :none do


### PR DESCRIPTION
This change aim to ignore json body parsing when body is not present. Sometimes libs consuming add the `Content-Type` header on the request, without this default value it is crashing the request because action_handler is trying to parse a body that does not exists.